### PR TITLE
Improve readme doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,7 @@ end
 Generate a migration:
 
 ``` sh
-rails generate migration add_profile_image_to_users profile_image_id:string &&
-profile_image_filename:string && profile_image_size:string &&
-profile_image_content_type:string
+rails generate migration add_profile_image_to_users profile_image_id profile_image_filename profile_image_size profile_image_content_type
 
 rake db:migrate
 ```


### PR DESCRIPTION
- Rails migration don't need sentence '&&' in each field.
- When you create a migration each field as created with string as default by rails.